### PR TITLE
Build Assets for Releases with Github Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,10 @@ jobs:
       - uses: actions/checkout@v1
       - name: Build UMDReplaceK for normal Release
         run: |
-          dotnet publish UMDReplaceK/UMDReplaceK.sln -c Release -r win-x86 --self-contained false -p:PublishSingleFile=true -p: -o win-x86
+          dotnet publish UMDReplaceK/UMDReplaceK.sln -c Release -r win-x86 --self-contained false -p:PublishSingleFile=true -o win-x86
       - name: Build UMDReplaceK for portable Release
         run: |
-          dotnet publish UMDReplaceK/UMDReplaceK.sln -c Release -r win-x86 --self-contained true -p:PublishSingleFile=true -o win-x86-sc
+          dotnet publish UMDReplaceK/UMDReplaceK.sln -c Release -r win-x86 --self-contained true -p:PublishSingleFile=true -p:PublishTrimmed=true -o win-x86-sc
       - name: Rename executables
         run: |
           mv win-x86/UMDReplaceK.exe win-x86/UMDReplaceK-win32.exe
@@ -36,10 +36,10 @@ jobs:
       - uses: actions/checkout@v1
       - name: Build UMDReplaceK for normal Release
         run: |
-          dotnet publish UMDReplaceK/UMDReplaceK.sln -c Release -r win-x64 --self-contained false -p:PublishSingleFile=true -p: -o win-x64
+          dotnet publish UMDReplaceK/UMDReplaceK.sln -c Release -r win-x64 --self-contained false -p:PublishSingleFile=true -o win-x64
       - name: Build UMDReplaceK for portable Release
         run: |
-          dotnet publish UMDReplaceK/UMDReplaceK.sln -c Release -r win-x64 --self-contained true -p:PublishSingleFile=true -o win-x64-sc
+          dotnet publish UMDReplaceK/UMDReplaceK.sln -c Release -r win-x64 --self-contained true -p:PublishSingleFile=true -p:PublishTrimmed=true -o win-x64-sc
       - name: Rename executables
         run: |
           mv win-x64/UMDReplaceK.exe win-x64/UMDReplaceK-win64.exe
@@ -62,10 +62,10 @@ jobs:
       - uses: actions/checkout@v1
       - name: Build UMDReplaceK for normal Release
         run: |
-          dotnet publish UMDReplaceK/UMDReplaceK.sln -c Release -r win-arm64 --self-contained false -p:PublishSingleFile=true -p: -o win-arm64
+          dotnet publish UMDReplaceK/UMDReplaceK.sln -c Release -r win-arm64 --self-contained false -p:PublishSingleFile=true -o win-arm64
       - name: Build UMDReplaceK for portable Release
         run: |
-          dotnet publish UMDReplaceK/UMDReplaceK.sln -c Release -r win-arm64 --self-contained true -p:PublishSingleFile=true -o win-arm64-sc
+          dotnet publish UMDReplaceK/UMDReplaceK.sln -c Release -r win-arm64 --self-contained true -p:PublishSingleFile=true -p:PublishTrimmed=true -o win-arm64-sc
       - name: Rename executables
         run: |
           mv win-arm64/UMDReplaceK.exe win-arm64/UMDReplaceK-winarm64.exe
@@ -74,12 +74,12 @@ jobs:
         uses: djn24/add-asset-to-release@v1
         with:
           token: ${{secrets.GITHUB_TOKEN}}
-          path: 'win-x64/UMDReplaceK-winarm64.exe'
+          path: 'win-arm64/UMDReplaceK-winarm64.exe'
       - name: Add portable build to release
         uses: djn24/add-asset-to-release@v1
         with:
           token: ${{secrets.GITHUB_TOKEN}}
-          path: 'win-x64-sc/UMDReplaceK-Portable-winarm64.exe'
+          path: 'win-arm64-sc/UMDReplaceK-Portable-winarm64.exe'
 
   build-release-linux:
     name: Build Linux Releases
@@ -88,10 +88,10 @@ jobs:
       - uses: actions/checkout@v1
       - name: Build UMDReplaceK for normal Release
         run: |
-          dotnet publish UMDReplaceK/UMDReplaceK.sln -c Release -r linux-x64 --self-contained false -p:PublishSingleFile=true -p: -o linux-x64
+          dotnet publish UMDReplaceK/UMDReplaceK.sln -c Release -r linux-x64 --self-contained false -p:PublishSingleFile=true -o linux-x64
       - name: Build UMDReplaceK for portable Release
         run: |
-          dotnet publish UMDReplaceK/UMDReplaceK.sln -c Release -r linux-x64 --self-contained true -p:PublishSingleFile=true -o linux-x64-sc
+          dotnet publish UMDReplaceK/UMDReplaceK.sln -c Release -r linux-x64 --self-contained true -p:PublishSingleFile=true -p:PublishTrimmed=true -o linux-x64-sc
       - name: Rename executables
         run: |
           mv linux-x64/UMDReplaceK linux-x64/UMDReplaceK-linux
@@ -114,10 +114,10 @@ jobs:
       - uses: actions/checkout@v1
       - name: Build UMDReplaceK for normal Release
         run: |
-          dotnet publish UMDReplaceK/UMDReplaceK.sln -c Release -r linux-arm64 --self-contained false -p:PublishSingleFile=true -p: -o linux-arm64
+          dotnet publish UMDReplaceK/UMDReplaceK.sln -c Release -r linux-arm64 --self-contained false -p:PublishSingleFile=true -o linux-arm64
       - name: Build UMDReplaceK for portable Release
         run: |
-          dotnet publish UMDReplaceK/UMDReplaceK.sln -c Release -r linux-arm64 --self-contained true -p:PublishSingleFile=true -o linux-arm64-sc
+          dotnet publish UMDReplaceK/UMDReplaceK.sln -c Release -r linux-arm64 --self-contained true -p:PublishSingleFile=true -p:PublishTrimmed=true -o linux-arm64-sc
       - name: Rename executables
         run: |
           mv linux-arm64/UMDReplaceK linux-arm64/UMDReplaceK-linux-arm
@@ -140,10 +140,10 @@ jobs:
       - uses: actions/checkout@v1
       - name: Build UMDReplaceK for normal Release
         run: |
-          dotnet publish UMDReplaceK/UMDReplaceK.sln -c Release -r osx-x64 --self-contained false -p:PublishSingleFile=true -p: -o osx-x64
+          dotnet publish UMDReplaceK/UMDReplaceK.sln -c Release -r osx-x64 --self-contained false -p:PublishSingleFile=true -o osx-x64
       - name: Build UMDReplaceK for portable Release
         run: |
-          dotnet publish UMDReplaceK/UMDReplaceK.sln -c Release -r osx-x64 --self-contained true -p:PublishSingleFile=true -o osx-x64-sc
+          dotnet publish UMDReplaceK/UMDReplaceK.sln -c Release -r osx-x64 --self-contained true -p:PublishSingleFile=true -p:PublishTrimmed=true -o osx-x64-sc
       - name: Rename executables
         run: |
           mv osx-x64/UMDReplaceK osx-x64/UMDReplaceK-osx
@@ -166,10 +166,10 @@ jobs:
       - uses: actions/checkout@v1
       - name: Build UMDReplaceK for normal Release
         run: |
-          dotnet publish UMDReplaceK/UMDReplaceK.sln -c Release -r osx-arm64 --self-contained false -p:PublishSingleFile=true -p: -o osx-arm64
+          dotnet publish UMDReplaceK/UMDReplaceK.sln -c Release -r osx-arm64 --self-contained false -p:PublishSingleFile=true -o osx-arm64
       - name: Build UMDReplaceK for portable Release
         run: |
-          dotnet publish UMDReplaceK/UMDReplaceK.sln -c Release -r osx-arm64 --self-contained true -p:PublishSingleFile=true -o osx-arm64-sc
+          dotnet publish UMDReplaceK/UMDReplaceK.sln -c Release -r osx-arm64 --self-contained true -p:PublishSingleFile=true -p:PublishTrimmed=true -o osx-arm64-sc
       - name: Rename executables
         run: |
           mv osx-arm64/UMDReplaceK osx-arm64/UMDReplaceK-osx-arm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,32 @@ jobs:
           token: ${{secrets.GITHUB_TOKEN}}
           path: 'win-x64-sc/UMDReplaceK-Portable-win64.exe'
 
+  build-release-win-arm64:
+    name: Build Windows arm64 Releases
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Build UMDReplaceK for normal Release
+        run: |
+          dotnet publish UMDReplaceK/UMDReplaceK.sln -c Release -r win-arm64 --self-contained false -p:PublishSingleFile=true -p: -o win-arm64
+      - name: Build UMDReplaceK for portable Release
+        run: |
+          dotnet publish UMDReplaceK/UMDReplaceK.sln -c Release -r win-arm64 --self-contained true -p:PublishSingleFile=true -o win-arm64-sc
+      - name: Rename executables
+        run: |
+          mv win-arm64/UMDReplaceK.exe win-arm64/UMDReplaceK-winarm64.exe
+          mv win-arm64-sc/UMDReplaceK.exe win-arm64-sc/UMDReplaceK-Portable-winarm64.exe
+      - name: Add normal build to release
+        uses: djn24/add-asset-to-release@v1
+        with:
+          token: ${{secrets.GITHUB_TOKEN}}
+          path: 'win-x64/UMDReplaceK-winarm64.exe'
+      - name: Add portable build to release
+        uses: djn24/add-asset-to-release@v1
+        with:
+          token: ${{secrets.GITHUB_TOKEN}}
+          path: 'win-x64-sc/UMDReplaceK-Portable-winarm64.exe'
+
   build-release-linux:
     name: Build Linux Releases
     runs-on: ubuntu-latest
@@ -81,6 +107,32 @@ jobs:
           token: ${{secrets.GITHUB_TOKEN}}
           path: 'linux-x64-sc/UMDReplaceK-Portable-linux'
 
+  build-release-linux-arm:
+    name: Build Linux arm Releases
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Build UMDReplaceK for normal Release
+        run: |
+          dotnet publish UMDReplaceK/UMDReplaceK.sln -c Release -r linux-arm64 --self-contained false -p:PublishSingleFile=true -p: -o linux-arm64
+      - name: Build UMDReplaceK for portable Release
+        run: |
+          dotnet publish UMDReplaceK/UMDReplaceK.sln -c Release -r linux-arm64 --self-contained true -p:PublishSingleFile=true -o linux-arm64-sc
+      - name: Rename executables
+        run: |
+          mv linux-arm64/UMDReplaceK linux-arm64/UMDReplaceK-linux-arm
+          mv linux-arm64-sc/UMDReplaceK linux-arm64-sc/UMDReplaceK-Portable-linux-arm
+      - name: Add normal build to release
+        uses: djn24/add-asset-to-release@v1
+        with:
+          token: ${{secrets.GITHUB_TOKEN}}
+          path: 'linux-arm64/UMDReplaceK-linux-arm'
+      - name: Add portable build to release
+        uses: djn24/add-asset-to-release@v1
+        with:
+          token: ${{secrets.GITHUB_TOKEN}}
+          path: 'linux-arm64-sc/UMDReplaceK-Portable-linux-arm'
+
   build-release-osx:
     name: Build macOS Releases
     runs-on: ubuntu-latest
@@ -106,3 +158,29 @@ jobs:
         with:
           token: ${{secrets.GITHUB_TOKEN}}
           path: 'osx-x64-sc/UMDReplaceK-Portable-osx'
+
+  build-release-osx-arm:
+    name: Build macOS M1 Releases
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Build UMDReplaceK for normal Release
+        run: |
+          dotnet publish UMDReplaceK/UMDReplaceK.sln -c Release -r osx-arm64 --self-contained false -p:PublishSingleFile=true -p: -o osx-arm64
+      - name: Build UMDReplaceK for portable Release
+        run: |
+          dotnet publish UMDReplaceK/UMDReplaceK.sln -c Release -r osx-arm64 --self-contained true -p:PublishSingleFile=true -o osx-arm64-sc
+      - name: Rename executables
+        run: |
+          mv osx-arm64/UMDReplaceK osx-arm64/UMDReplaceK-osx-arm
+          mv osx-arm64-sc/UMDReplaceK osx-arm64-sc/UMDReplaceK-Portable-osx-arm
+      - name: Add normal build to release
+        uses: djn24/add-asset-to-release@v1
+        with:
+          token: ${{secrets.GITHUB_TOKEN}}
+          path: 'osx-arm64/UMDReplaceK-osx-arm'
+      - name: Add portable build to release
+        uses: djn24/add-asset-to-release@v1
+        with:
+          token: ${{secrets.GITHUB_TOKEN}}
+          path: 'osx-arm64-sc/UMDReplaceK-Portable-osx-arm'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,108 @@
+﻿name: Build UMDReplaceK Release Assets
+on: release
+
+jobs:
+
+  build-release-win32:
+    name: Build Windows x86 Releases
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Build UMDReplaceK for normal Release
+        run: |
+          dotnet publish UMDReplaceK/UMDReplaceK.sln -c Release -r win-x86 --self-contained false -p:PublishSingleFile=true -p: -o win-x86
+      - name: Build UMDReplaceK for portable Release
+        run: |
+          dotnet publish UMDReplaceK/UMDReplaceK.sln -c Release -r win-x86 --self-contained true -p:PublishSingleFile=true -o win-x86-sc
+      - name: Rename executables
+        run: |
+          mv win-x86/UMDReplaceK.exe win-x86/UMDReplaceK-win32.exe
+          mv win-x86-sc/UMDReplaceK.exe win-x86-sc/UMDReplaceK-Portable-win32.exe
+      - name: Add normal build to release
+        uses: djn24/add-asset-to-release@v1
+        with:
+          token: ${{secrets.GITHUB_TOKEN}}
+          path: 'win-x86/UMDReplaceK-win32.exe'
+      - name: Add portable build to release
+        uses: djn24/add-asset-to-release@v1
+        with:
+          token: ${{secrets.GITHUB_TOKEN}}
+          path: 'win-x86-sc/UMDReplaceK-Portable-win32.exe'
+
+  build-release-win64:
+    name: Build Windows x64 Releases
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Build UMDReplaceK for normal Release
+        run: |
+          dotnet publish UMDReplaceK/UMDReplaceK.sln -c Release -r win-x64 --self-contained false -p:PublishSingleFile=true -p: -o win-x64
+      - name: Build UMDReplaceK for portable Release
+        run: |
+          dotnet publish UMDReplaceK/UMDReplaceK.sln -c Release -r win-x64 --self-contained true -p:PublishSingleFile=true -o win-x64-sc
+      - name: Rename executables
+        run: |
+          mv win-x64/UMDReplaceK.exe win-x64/UMDReplaceK-win64.exe
+          mv win-x64-sc/UMDReplaceK.exe win-x64-sc/UMDReplaceK-Portable-win64.exe
+      - name: Add normal build to release
+        uses: djn24/add-asset-to-release@v1
+        with:
+          token: ${{secrets.GITHUB_TOKEN}}
+          path: 'win-x64/UMDReplaceK-win64.exe'
+      - name: Add portable build to release
+        uses: djn24/add-asset-to-release@v1
+        with:
+          token: ${{secrets.GITHUB_TOKEN}}
+          path: 'win-x64-sc/UMDReplaceK-Portable-win64.exe'
+
+  build-release-linux:
+    name: Build Linux Releases
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Build UMDReplaceK for normal Release
+        run: |
+          dotnet publish UMDReplaceK/UMDReplaceK.sln -c Release -r linux-x64 --self-contained false -p:PublishSingleFile=true -p: -o linux-x64
+      - name: Build UMDReplaceK for portable Release
+        run: |
+          dotnet publish UMDReplaceK/UMDReplaceK.sln -c Release -r linux-x64 --self-contained true -p:PublishSingleFile=true -o linux-x64-sc
+      - name: Rename executables
+        run: |
+          mv linux-x64/UMDReplaceK linux-x64/UMDReplaceK-linux
+          mv linux-x64-sc/UMDReplaceK linux-x64-sc/UMDReplaceK-Portable-linux
+      - name: Add normal build to release
+        uses: djn24/add-asset-to-release@v1
+        with:
+          token: ${{secrets.GITHUB_TOKEN}}
+          path: 'linux-x64/UMDReplaceK-linux'
+      - name: Add portable build to release
+        uses: djn24/add-asset-to-release@v1
+        with:
+          token: ${{secrets.GITHUB_TOKEN}}
+          path: 'linux-x64-sc/UMDReplaceK-Portable-linux'
+
+  build-release-osx:
+    name: Build macOS Releases
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Build UMDReplaceK for normal Release
+        run: |
+          dotnet publish UMDReplaceK/UMDReplaceK.sln -c Release -r osx-x64 --self-contained false -p:PublishSingleFile=true -p: -o osx-x64
+      - name: Build UMDReplaceK for portable Release
+        run: |
+          dotnet publish UMDReplaceK/UMDReplaceK.sln -c Release -r osx-x64 --self-contained true -p:PublishSingleFile=true -o osx-x64-sc
+      - name: Rename executables
+        run: |
+          mv osx-x64/UMDReplaceK osx-x64/UMDReplaceK-osx
+          mv osx-x64-sc/UMDReplaceK osx-x64-sc/UMDReplaceK-Portable-osx
+      - name: Add normal build to release
+        uses: djn24/add-asset-to-release@v1
+        with:
+          token: ${{secrets.GITHUB_TOKEN}}
+          path: 'osx-x64/UMDReplaceK-osx'
+      - name: Add portable build to release
+        uses: djn24/add-asset-to-release@v1
+        with:
+          token: ${{secrets.GITHUB_TOKEN}}
+          path: 'osx-x64-sc/UMDReplaceK-Portable-osx'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,7 @@
 ﻿name: Build UMDReplaceK Release Assets
-on: release
+on: 
+  release:
+    types: [published]
 
 jobs:
 


### PR DESCRIPTION
This PR will allow you to create a Github release, and Github will then build and add all the executables to the Release assets. 

This workflow will build single-file executables for Windows x86, Windows x64 and Windows ARM64, as well as Linux and macOS (both x64 and ARM64). All of these versions are built in both self-contained -- which includes the .NET runtime -- and not self-contained versions, which require the .NET 6 runtime. Self-contained builds are trimmed to reduce the amount of .NET shipped with the release. 